### PR TITLE
AutoYaST: Use fcoe suffix when auto_vlan == 'yes'

### DIFF
--- a/package/yast2-fcoe-client.changes
+++ b/package/yast2-fcoe-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar  7 14:00:29 UTC 2018 - knut.anderssen@suse.com
+
+- Fix wrong interface name with auto_vlan=yes also during an
+  auto-installation (bsc#1078991)
+- 3.1.16
+
+-------------------------------------------------------------------
 Fri Sep 15 11:31:03 UTC 2017 - mvidner@suse.com
 
 - Fix wrong interface name with auto_vlan=yes (bsc#1043419)

--- a/package/yast2-fcoe-client.spec
+++ b/package/yast2-fcoe-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-fcoe-client
-Version:        3.1.15
+Version:        3.1.16
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/fcoe-client_auto.rb
+++ b/src/clients/fcoe-client_auto.rb
@@ -150,11 +150,14 @@ module Yast
           output = {}
           ifcfg_file = ""
           status_map = {}
-          if Ops.get_string(card, "fcoe_vlan", "") == FcoeClient.NOT_CONFIGURED
-            command = Builtins.sformat(
-              "fipvlan -c -s %1",
-              Ops.get_string(card, "dev_name", "")
-            )
+          dev_name = card["dev_name"]
+          if card["fcoe_vlan"] == FcoeClient.NOT_CONFIGURED
+            if card["auto_vlan"] == "yes"
+              command = "fipvlan -c -s -f '-fcoe' #{dev_name}"
+            else
+              command = "fipvlan -c -s #{dev_name}"
+            end
+
             ifcfg_file = Builtins.sformat(
               "/etc/sysconfig/network/ifcfg-%1.%2",
               Ops.get_string(card, "dev_name", ""),


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1078991

Maybe I'm wrong but seems that the patch added in https://bugzilla.suse.com/show_bug.cgi?id=1043419 should be applied also during an auto-installation