### PR TITLE
Use correct VLAN interface name in the finish client

### DIFF
--- a/package/yast2-fcoe-client.changes
+++ b/package/yast2-fcoe-client.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Feb 20 13:09:42 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Use the correct file names when copying the configuration of the
+  FCoE VLANs to the target system at the end of installation
+  (related to bsc#1163343).
+- 4.2.2
+
+-------------------------------------------------------------------
 Mon Aug 26 09:37:36 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/yast2-fcoe-client.spec
+++ b/package/yast2-fcoe-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-fcoe-client
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Summary:        YaST2 - Configuration of Fibre Channel over Ethernet
 Group:          System/YaST

--- a/src/clients/fcoe-client_finish.rb
+++ b/src/clients/fcoe-client_finish.rb
@@ -87,40 +87,39 @@ module Yast
           Builtins.y2milestone("Nothing to do")
         end
 
-        Builtins.foreach(@netcards) do |card|
-          command = ""
-          file_name = ""
-          if Ops.get_string(card, "fcoe_vlan", "") != FcoeClient.NOT_AVAILABLE &&
-              Ops.get_string(card, "fcoe_vlan", "") != FcoeClient.NOT_CONFIGURED
-            # FCoE VLAN interface is configured -> start services
-            @start_services = true
+        @netcards.each do |card|
+          fcoe_vlan = card.fetch("fcoe_vlan", "")
+          next if fcoe_vlan == FcoeClient.NOT_AVAILABLE || fcoe_vlan == FcoeClient.NOT_CONFIGURED
 
-            # copy sysconfig files
-            file_name = Builtins.sformat(
-              "/etc/sysconfig/network/ifcfg-%1.%2",
-              Ops.get_string(card, "dev_name", ""),
-              Ops.get_string(card, "vlan_interface", "")
-            )
-            command = Builtins.sformat(
-              "/usr/bin/cp -a %1 %2/etc/sysconfig/network",
-              file_name.shellescape,
-              Installation.destdir.shellescape
-            )
-            Builtins.y2milestone("Executing command: %1", command)
-            WFM.Execute(path(".local.bash"), command)
+          # FCoE VLAN interface is configured -> start services
+          @start_services = true
 
-            file_name = Builtins.sformat(
-              "/etc/sysconfig/network/ifcfg-%1",
-              Ops.get_string(card, "dev_name", "")
-            )
-            command = Builtins.sformat(
-              "/usr/bin/cp -a %1 %2/etc/sysconfig/network",
-              file_name.shellescape,
-              Installation.destdir.shellescape
-            )
-            Builtins.y2milestone("Executing command: %1", command)
-            WFM.Execute(path(".local.bash"), command)
-          end
+          # copy sysconfig files
+          file_name = Builtins.sformat(
+            "/etc/sysconfig/network/ifcfg-%1.%2",
+            Ops.get_string(card, "dev_name", ""),
+            Ops.get_string(card, "vlan_interface", "")
+          )
+
+          command = Builtins.sformat(
+            "/usr/bin/cp -a %1 %2/etc/sysconfig/network",
+            file_name.shellescape,
+            Installation.destdir.shellescape
+          )
+          Builtins.y2milestone("Executing command: %1", command)
+          WFM.Execute(path(".local.bash"), command)
+
+          file_name = Builtins.sformat(
+            "/etc/sysconfig/network/ifcfg-%1",
+            Ops.get_string(card, "dev_name", "")
+          )
+          command = Builtins.sformat(
+            "/usr/bin/cp -a %1 %2/etc/sysconfig/network",
+            file_name.shellescape,
+            Installation.destdir.shellescape
+          )
+          Builtins.y2milestone("Executing command: %1", command)
+          WFM.Execute(path(".local.bash"), command)
         end
 
         if @start_services

--- a/src/clients/fcoe-client_finish.rb
+++ b/src/clients/fcoe-client_finish.rb
@@ -88,18 +88,14 @@ module Yast
         end
 
         @netcards.each do |card|
-          fcoe_vlan = card.fetch("fcoe_vlan", "")
-          next if fcoe_vlan == FcoeClient.NOT_AVAILABLE || fcoe_vlan == FcoeClient.NOT_CONFIGURED
+          iface_name = FcoeClient.fcoe_vlan(card)
+          next if iface_name.nil?
 
           # FCoE VLAN interface is configured -> start services
           @start_services = true
 
           # copy sysconfig files
-          file_name = Builtins.sformat(
-            "/etc/sysconfig/network/ifcfg-%1.%2",
-            Ops.get_string(card, "dev_name", ""),
-            Ops.get_string(card, "vlan_interface", "")
-          )
+          file_name = "/etc/sysconfig/network/ifcfg-#{iface_name}"
 
           command = Builtins.sformat(
             "/usr/bin/cp -a %1 %2/etc/sysconfig/network",

--- a/src/modules/FcoeClient.rb
+++ b/src/modules/FcoeClient.rb
@@ -1689,7 +1689,8 @@ module Yast
     # @param card [Hash] a hash with all the information about a network interface
     # @return [String, nil] nil if no FCoE VLAN is configured for the given interface
     def fcoe_vlan(card)
-      fcoe_vlan = card.fetch("fcoe_vlan", "")
+      fcoe_vlan = card["fcoe_vlan"]
+      return nil if fcoe_vlan.nil? || fcoe_vlan.empty?
       return nil if fcoe_vlan == @NOT_AVAILABLE || fcoe_vlan == @NOT_CONFIGURED
 
       fcoe_vlan

--- a/src/modules/FcoeClient.rb
+++ b/src/modules/FcoeClient.rb
@@ -46,7 +46,7 @@ module Yast
       # @!method [](k)
       #   I am not sure when the keys are present/absent :-/
       #   @option k [String] 'fcoe_vlan'
-      #     "eth1.500" or "not configured" or "not available"
+      #     "eth1.500-fcoe" or "not configured" or "not available"
       #   @option k [String] 'vlan_interface'
       #     "500", or "0" for no VLAN used;  yes, the name is nonsense, should be "vid"
       #   @option k [String] 'dev_name'     "eth1"
@@ -1690,6 +1690,7 @@ module Yast
     # @return [String, nil] nil if no FCoE VLAN is configured for the given interface
     def fcoe_vlan(card)
       fcoe_vlan = card["fcoe_vlan"]
+      # It should never contain a nil or an empty string, but better safe than sorry
       return nil if fcoe_vlan.nil? || fcoe_vlan.empty?
       return nil if fcoe_vlan == @NOT_AVAILABLE || fcoe_vlan == @NOT_CONFIGURED
 

--- a/test/fcoe_client_write_spec.rb
+++ b/test/fcoe_client_write_spec.rb
@@ -16,32 +16,67 @@ describe Yast::FcoeClientClass do
   end
 
   describe "#WriteSysconfigFiles" do
-    context "for odd cases" do
-      before do
-        interfaces = [
-          { "fcoe_vlan" => "not available" },
-          { "fcoe_vlan" => "not configured" },
+    before do
+      allow(subject).to receive(:GetNetworkCards).and_return(interfaces)
+    end
+
+
+    context "when no VLAN was created for any of the interfaces" do
+      let(:interfaces) do
+        [
+          { "dev_name" => "eth0", "fcoe_vlan" => "not available" },
+          { "dev_name" => "eth1", "fcoe_vlan" => "not configured" }
         ]
-        expect(subject).to receive(:GetNetworkCards).and_return(interfaces)
       end
 
       it "smokes not" do
         expect { subject.WriteSysconfigFiles }.to_not raise_error
       end
+
+      it "writes nothing into /etc/sysconfig/network" do
+        expect(Yast::SCR).to_not receive(:Write)
+          .with(path_matching(/^\.network\..*/), anything)
+
+        subject.WriteSysconfigFiles
+      end
     end
 
-    context "for a small FCoE setup" do
-      before do
-        interfaces = [
-          { "fcoe_vlan" => "eth1.500" }
+    context "if an FCoE VLAN is created for some interface" do
+      let(:interfaces) do
+        [
+          { "dev_name" => "eth0", "fcoe_vlan" => "not available" },
+          { "dev_name" => "eth1", "fcoe_vlan" => "eth1.500-fcoe" },
         ]
-        expect(subject).to receive(:GetNetworkCards).and_return(interfaces)
+      end
+
+      before do
         allow(Yast::SCR).to receive(:Write).and_return(true)
         allow(Yast::FileUtils).to receive(:Exists).and_return(false)
       end
 
       it "smokes not" do
         expect { subject.WriteSysconfigFiles }.to_not raise_error
+      end
+
+      it "writes the sysconfig configuration for the interface and its FCoE VLAN" do
+        expect(Yast::SCR).to receive(:Write)
+          .with(path_matching(/^\.network\.value\.\"eth1.500-fcoe\"\.*/), anything)
+        expect(Yast::SCR).to receive(:Write)
+          .with(path_matching(/^\.network\.value\.\"eth1\"\.*/), anything)
+        # A final call is also needed to flush the content
+        expect(Yast::SCR).to receive(:Write).with(Yast::Path.new(".network"), nil)
+
+        subject.WriteSysconfigFiles
+      end
+
+      it "writes nothing in /etc/sysconfig/network for interfaces without FCoE VLAN" do
+        allow(Yast::SCR).to receive(:Write) do |path, value|
+          # All calls to SCR.Write must contain a path starting with ".network.value.\"eth1"
+          # or exactly the path ".network" (for flushing)
+          expect(path.to_s).to match("(^\.network$)|(^\.network\.value\.\"eth1(\.|\"))")
+        end
+
+        subject.WriteSysconfigFiles
       end
     end
   end

--- a/test/fcoe_client_write_spec.rb
+++ b/test/fcoe_client_write_spec.rb
@@ -25,7 +25,8 @@ describe Yast::FcoeClientClass do
       let(:interfaces) do
         [
           { "dev_name" => "eth0", "fcoe_vlan" => "not available" },
-          { "dev_name" => "eth1", "fcoe_vlan" => "not configured" }
+          { "dev_name" => "eth1", "fcoe_vlan" => "not configured" },
+          { "dev_name" => "eth2", "fcoe_vlan" => "" },
         ]
       end
 
@@ -46,6 +47,7 @@ describe Yast::FcoeClientClass do
         [
           { "dev_name" => "eth0", "fcoe_vlan" => "not available" },
           { "dev_name" => "eth1", "fcoe_vlan" => "eth1.500-fcoe" },
+          { "dev_name" => "eth2", "fcoe_vlan" => "" },
         ]
       end
 


### PR DESCRIPTION
## Problem

There was a mismatch between the filenames used when creating the FCoE configuration (during installation) and the filenames used when trying to copy that configuration to the target system (at the end of the installation).

Example of some log lines during configuration:

```
clients/inst_fcoe-client.rb:116 Writing sysconfig files
modules/FcoeClient.rb:1247 Writing /etc/sysconfig/network/ifcfg-eth4.11-fcoe
modules/FcoeClient.rb:1257 Writing /etc/sysconfig/network/ifcfg-eth4
modules/FcoeClient.rb:1247 Writing /etc/sysconfig/network/ifcfg-eth5.11-fcoe
modules/FcoeClient.rb:1257 Writing /etc/sysconfig/network/ifcfg-eth5
```

And some lines of the very same log at the end of installation:

```
clients/fcoe-client_finish.rb:62 starting fcoe-client_finish
clients/fcoe-client_finish.rb:109 Executing: cp -a /etc/sysconfig/network/ifcfg-eth4.11 /mnt/etc/sysconfig/network
clients/fcoe-client_finish.rb:121 Executing: cp -a /etc/sysconfig/network/ifcfg-eth4 /mnt/etc/sysconfig/network
clients/fcoe-client_finish.rb:109 Executing: cp -a /etc/sysconfig/network/ifcfg-eth5.11 /mnt/etc/sysconfig/network
clients/fcoe-client_finish.rb:121 Executing: cp -a /etc/sysconfig/network/ifcfg-eth5 /mnt/etc/sysconfig/network
```

Note the mismatch between ifcfg-eth4.11-fcoe and ifcfg-eth4.11 (and same applies to eth5).

This is related to [bsc#1163343](https://bugzilla.suse.com/show_bug.cgi?id=1163343), although the error turned out to be harmless because the network finish client is executed at a later point in time and does the right thing.

## Solution

Fix the finish client to use the same interface name than `FcoeClient`.

This pull request also includes a preliminary commit to kill some YCP zombies. Please review commit by commit. That first commit looks like it changes a lot of code, but is mostly indentation because changes several structures like this:

```ruby
Builtins.foreach(collection) do |item|
  surplus_initializations
  if something?
     do_whatever
  end
end
```

Into this

```ruby
collection.each do |item|
  next unless something?
  do_whatever
end
```

## Testing

Added unit test for the module `FcoeClient` (green before and after the changes).

Unit test for the client `fcoe-client_finish` not added because is one of those old untestable clients. It should be extracted into a proper class in the `lib` directory, but we are in release candidate phase already.