### PR TITLE
Use the new yast2-network fcoe connection generator (bsc#1199554)

### DIFF
--- a/package/yast2-fcoe-client.changes
+++ b/package/yast2-fcoe-client.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jul 21 10:07:04 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Use yast2-network to write the sysconfig files in order to be
+  aware of the new connections added during the installation
+  (bsc#1199554).
+- 4.3.2
+
+-------------------------------------------------------------------
 Fri Feb 18 11:47:53 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Added AutoYaST schema (bsc#1194895)

--- a/package/yast2-fcoe-client.spec
+++ b/package/yast2-fcoe-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-fcoe-client
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Summary:        YaST2 - Configuration of Fibre Channel over Ethernet
 Group:          System/YaST
@@ -28,10 +28,12 @@ Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:	perl-XML-Writer update-desktop-files yast2
 BuildRequires:  yast2-devtools >= 4.2.2
+BuildRequires:  yast2-network >= 4.3.85
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 
 # Yast2::Systemd::Service
 Requires:       yast2 >= 4.1.3
+Requires:       yast2-network >= 4.3.85
 Requires:       fcoe-utils
 Requires:       yast2-ruby-bindings >= 1.0.0
 

--- a/src/modules/FcoeClient.rb
+++ b/src/modules/FcoeClient.rb
@@ -1229,7 +1229,6 @@ module Yast
 
     # Writes the network configuration for the FCoE Vlan interface and the related parent device
     #
-    # @param card [Hash] a hash with all the information about a network interface
     # @return [Boolean] whether it wrote the ifcfg files for netcards or not
     def WriteSysconfigFiles
       netcards = GetNetworkCards().select { |c| fcoe_vlan?(c) }

--- a/test/fcoe_client_write_spec.rb
+++ b/test/fcoe_client_write_spec.rb
@@ -36,11 +36,7 @@ describe Yast::FcoeClientClass do
         ]
       end
 
-      it "smokes not" do
-        expect { subject.WriteSysconfigFiles }.to_not raise_error
-      end
-
-      it "does not nodify the network configuration" do
+      it "does not modify the network configuration" do
         expect(Yast::Lan).to_not receive(:write_config)
 
         subject.WriteSysconfigFiles
@@ -71,10 +67,6 @@ describe Yast::FcoeClientClass do
         expect(Yast::Lan).to receive(:write_config).with(only: [:connections])
 
         subject.WriteSysconfigFiles
-      end
-
-      it "smokes not" do
-        expect { subject.WriteSysconfigFiles }.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
## Problem

When installing a server with FCoE on a target LUN it gets stuck in subsequent reboots due to a wrong network configuration.

https://bugzilla.suse.com/show_bug.cgi?id=1199554
https://trello.com/c/vA1WOdhV

It depends on: https://github.com/yast/yast-network/pull/1301

## Solution

Added a class in [yast2-network](https://github.com/yast/yast-network/pull/1301) to generate the needed configuration for a FCoE device being aware of it during installation. This module will use that new class for adding the new connections and will write the config if modified.

## Testing

Adapted unit tests
Tested manually (pending due to problems with server)
